### PR TITLE
Fixed exception thrown by SassHandler with apps on virtual directories

### DIFF
--- a/NSass.Handler/SassHandler.cs
+++ b/NSass.Handler/SassHandler.cs
@@ -9,7 +9,7 @@ namespace NSass
 
 		public void ProcessRequest(HttpContext context)
 		{
-			string filename = context.Server.MapPath(String.Format("~{0}", context.Request.Path));
+			string filename = context.Server.MapPath(context.Request.AppRelativeCurrentExecutionFilePath);
 			string root = context.Server.MapPath("~");
 
 			string output = _sassCompiler.CompileFile(filename, additionalIncludePaths: new[] { root });


### PR DESCRIPTION
When an application is hosted on IIS through a virtual directory, (e.g.,
"/my-app" as the entry point instead of "/"), SassHandler will no longer
throw an exception when attempting to compile a SCSS file.